### PR TITLE
fixbug: favorite spelling mistakes

### DIFF
--- a/h5LiveDemo/src/js/favoriate/index.js
+++ b/h5LiveDemo/src/js/favoriate/index.js
@@ -13,7 +13,7 @@ export default class Favoriate {
 		})
 	}
 
-	favoriate() {
+	favorite() {
 		let length = this.imgNames.length;
 		this.index = (this.index < length) ? this.index : 0;
 		name = this.imgNames[this.index];


### PR DESCRIPTION
The folder name is also misspelled,  the right spell  is  `favorite`, not `favoriate`